### PR TITLE
add zsh support, remove extra output on macOS

### DIFF
--- a/melee.sh
+++ b/melee.sh
@@ -98,12 +98,12 @@ melee() {
     esac
 
     success() {
-        eval "($PLAY_COMMAND $MELEE_DIR/sounds/success.wav > /dev/null 2>&1 & disown)"
+        eval "($PLAY_COMMAND $MELEE_DIR/sounds/success.wav > /dev/null 2>&1 & disown 2> /dev/null)"
         return 0
     }
     failure() {
         local rc=$?
-        eval "($PLAY_COMMAND $MELEE_DIR/sounds/failure.wav > /dev/null 2>&1 & disown)"
+        eval "($PLAY_COMMAND $MELEE_DIR/sounds/failure.wav > /dev/null 2>&1 & disown 2> /dev/null)"
         return $rc
     }
 


### PR DESCRIPTION
This pull-request adds zsh support by:
1. checking what shell is being used, and if it is zsh, using a different, zsh-compatible command to locate the `MELEE_DIR` directory; and,
2. using `eval` to run the play command.

This PR also contains a second, smaller commit that removes the `(eval):disown:1: no current job` message when the script is run on macOS.

I'm quite a novice at scripting, so please tell me if anything looks wrong. I would greatly appreciate feedback. Specifically, the case block in the `current_shell()` is likely unnecessary, but I wasn't sure how I could strip a potential leading dash from `ps`'s output.